### PR TITLE
organize build scripts, add gitignore, justfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Release archives
+dist/
+*.7z
+
+# Build artifacts
+main
+

--- a/build/create_sprig_release.bat
+++ b/build/create_sprig_release.bat
@@ -5,8 +5,12 @@ REM This bat file will create a 7z archive of the sprig folder named sprigV<vers
 REM It excludes all git-related files and this script itself
 REM You need 7zip installed to use this script
 
+REM Navigate to repository root
+cd /d "%~dp0\.."
+
 REM Define variables
 set "archiveName=sprig"
+set "destinationDir=dist"
 set "version="
 
 REM Check for the sprig version file
@@ -26,12 +30,15 @@ if "%version%"=="" (
     exit /b 1
 )
 
+REM Create destination directory
+if not exist "%destinationDir%" mkdir "%destinationDir%"
+
 REM Create the 7z file name
-set "output7z=%archiveName%V%version%.7z"
+set "output7z=%destinationDir%\%archiveName%V%version%.7z"
 
 REM Create the 7z file excluding this script and all git-related files
 echo Creating 7z archive "%output7z%"...
-7z a -t7z -mx=9 -xr!.git* -x!.gitignore -x!.gitattributes -x!"%~nx0" -x!create_sprig_release.sh -x!main -x!TODO.txt "%output7z%" *
+7z a -t7z -mx=9 -xr!.git* -xr!build -x!.gitignore -x!.gitattributes -x!justfile -x!main -x!TODO.txt "%output7z%" *
 
 REM Check if 7z creation was successful
 if %errorlevel% neq 0 (

--- a/build/create_sprig_release.sh
+++ b/build/create_sprig_release.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")/.."
 
 ARCHIVE_NAME="sprig"
 VERSION_FILE="sprig/version"
+DESTINATION_DIR="dist"
 VERSION=
 
 if [ ! -f "$VERSION_FILE" ]; then
     echo "Error: could not find file $VERSION_FILE"
-    read
     exit 1
 fi
 
@@ -16,25 +16,24 @@ VERSION=$(< "$VERSION_FILE")
 
 if [ "$VERSION" == "" ]; then
     echo "Error: failed to retrieve version from $VERSION_FILE"
-    read
     exit 1
 fi
 
-OUTPUT_7Z="${ARCHIVE_NAME}V${VERSION}.7z"
+mkdir -p "$DESTINATION_DIR"
+
+OUTPUT_7Z="${DESTINATION_DIR}/${ARCHIVE_NAME}V${VERSION}.7z"
 
 if [ -f "$OUTPUT_7Z" ]; then
     echo "Removing already existing $OUTPUT_7Z"
     rm "$OUTPUT_7Z"
 fi
 
-7z a -t7z -mx=9 -xr!.git* -x!.gitignore -x!.gitattributes -x!"$(basename "$0")" -x!create_sprig_release.bat -x!main -x!TODO.txt "$OUTPUT_7Z" *
+7z a -t7z -mx=9 -xr!.git* -xr!build -x!.gitignore -x!.gitattributes -x!justfile -x!main -x!TODO.txt "$OUTPUT_7Z" *
 
 if [ $? -ne 0 ]; then
     echo "Error: failed to create 7z archive"
-    read
     exit 1
 fi
 
 echo "7z archive $OUTPUT_7Z created successfully"
-read
 exit 0

--- a/justfile
+++ b/justfile
@@ -1,0 +1,14 @@
+# List available recipes
+default:
+    @just --list
+
+# Build a release archive
+build:
+    @echo "Building release..."
+    @bash build/create_sprig_release.sh
+
+# Clean build artifacts
+clean:
+    @echo "Cleaning build artifacts..."
+    @rm -rf dist/*.7z
+    @echo "Clean complete"


### PR DESCRIPTION
- moved release scripts into their own dir
- add justfile at project root to centralize build commands (deploy to sd card/over ssh with .env would be next addition imo)
- lean gitignore for build artifacts
- minor tweaks to release scripts to exit cleanly, path to dist dir