### PR TITLE
fix: remount the SD card read-only before poweroff

### DIFF
--- a/sprig/scripts/save_poweroff.sh
+++ b/sprig/scripts/save_poweroff.sh
@@ -25,5 +25,34 @@ sync
 if is_mini_og; then
     reboot          # OG Mini hangs if you use the poweroff command
 else
-    poweroff
+    # Storage-only tail for Wi-Fi Miyoo models. Keep every stock SprigUI
+    # autoresume, signal, wait, and sync operation above unchanged. Closing
+    # inherited standard descriptors prevents an SD-backed caller log from
+    # keeping the FAT filesystem writable during the remount.
+    exec </dev/null >/dev/null 2>&1
+    PATH=/usr/sbin:/usr/bin:/sbin:/bin
+    export PATH
+
+    # A successful vfat RW-to-RO remount performs the same FAT clean-state
+    # transition as unmount, while keeping SprigUI's bind mounts readable.
+    # Verify the exact base mount after the single attempt.  On failure, use
+    # the same firmware poweroff action as stock rather than leaving a frozen
+    # screen that would force a dirtier hardware cut.
+    sd_ro_count=0
+    if mount -o remount,ro /dev/mmcblk0p1 /mnt/SDCARD; then
+        while read -r sd_device sd_mount sd_type sd_options sd_rest; do
+            if [ "$sd_device" = "/dev/mmcblk0p1" ] && \
+                    [ "$sd_mount" = "/mnt/SDCARD" ] && \
+                    [ "$sd_type" = "vfat" ]; then
+                case ",$sd_options," in
+                    *,ro,*) sd_ro_count=$((sd_ro_count + 1)) ;;
+                esac
+            fi
+        done < /proc/mounts
+    fi
+    if [ "$sd_ro_count" -ne 1 ]; then
+        /sbin/poweroff
+        exit $?
+    fi
+    /sbin/poweroff
 fi


### PR DESCRIPTION
## Summary
- preserves SprigUI's existing autoresume capture and app/emulator shutdown sequence
- after the final stock `sync`, closes inherited standard streams and uses a system-only `PATH`
- makes one exact read-only remount attempt for `/dev/mmcblk0p1` at `/mnt/SDCARD`
- verifies the base vfat mount is read-only, then uses the same stock `/sbin/poweroff` action whether the remount succeeded or failed

## Scope

This is for SprigUI's supported Miyoo Mini Flip target. The Mini OG reboot path is unchanged.

SprigUI keeps SD-backed bind mounts active during shutdown. A direct adaptation of full spruceOS's RAM stage/unmount flow was tested on the Mini Flip and froze before the RAM stage started, so this change intentionally leaves those binds readable and remounts only the base FAT volume read-only.

## Root cause

The normal software-shutdown path synced the filesystem and immediately called `poweroff`, but never transitioned the FAT volume out of its writable state. On a Miyoo Mini Flip, documented quick-save shutdowns could leave the card dirty even though `save_poweroff.sh` completed normally. A vfat read-only remount commits the FAT clean-state transition while leaving SprigUI's bind-mounted runtime files readable for the firmware handoff.

The failure path deliberately retains stock behavior: it still powers off rather than freezing the UI and forcing a hard cut. Everything through autoresume capture, process signaling/waits, and the original `sync` is byte-identical to the current `development` script. This does not add a second-stage shutdown script or import the different spruceOS shutdown topology.

## Validation

- `sh -n` and Git whitespace checks
- nine-case inert equivalence/failure harness, including autoresume capture, an emulator wait, remount command failure, false-success verification, duplicate/wrong mount records, and the untouched Mini OG reboot path
- three physical Mini Flip button shutdowns: main menu, in-game with autoresume capture, then in-game again after resume
- confirmed autoresume, RetroArch auto-state, and SRAM behavior remained intact
- after the patched shutdowns: Windows reported `NOT Dirty` and `Healthy/OK`; read-only CHKDSK found no filesystem errors

Fixes #236